### PR TITLE
Improve reliability of test_discard by resetting the pre-state

### DIFF
--- a/observed_test.py
+++ b/observed_test.py
@@ -225,7 +225,7 @@ class TestBasics:
     """Test that observers are called when the observed object is called."""
 
     @classmethod
-    def setup_class(self):
+    def setup_method(self):
         self.buf = []
 
     @classmethod


### PR DESCRIPTION
This PR aims to improve the reliability of the test `TestBasics.test_discard` by resetting the pre-state.

The test can fail if `self.buf` is in a polluted state before running the test:
```        a.bar()
>       assert a.buf == ['abar']
E       AssertionError: assert ['abar', 'abar'] == ['abar']
E         Left contains one more item: 'abar'
E         Use -v to get the full diff

observed_test.py:291: AssertionError
```